### PR TITLE
Update to use node24 to address deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: Pip Installer v2
 author: Insights Engineering
 description: An action to automatically install Python Pip packages.
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'arrow-down'


### PR DESCRIPTION
Github will be deprecating node 20 in actions this summer: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/